### PR TITLE
False Library Directory Bug Fixed

### DIFF
--- a/Source/SodiumUE4/Private/SodiumUE4.cpp
+++ b/Source/SodiumUE4/Private/SodiumUE4.cpp
@@ -21,7 +21,8 @@ void FSodiumUE4Module::StartupModule()
 	// Add on the relative location of the third party dll and load it
 	FString LibraryPath;
 #if PLATFORM_WINDOWS
-	LibraryPath = FPaths::Combine(*BaseDir, TEXT("Binaries/ThirdParty/SodiumUE4Library/Win64/libsodiumUE4.dll"));
+	// LibraryPath = FPaths::Combine(*BaseDir, TEXT("Binaries/ThirdParty/SodiumUE4Library/Win64/libsodiumUE4.dll"));
+	LibraryPath = FPaths::Combine(*BaseDir, TEXT("Source/ThirdParty/SodiumUE4Library/x64/Release/libsodiumUE4.dll"));
 
 	libsodiumUE4Handle = !LibraryPath.IsEmpty() ? FPlatformProcess::GetDllHandle(*LibraryPath) : nullptr;
 


### PR DESCRIPTION
Plugin was not working on 4.12. I made this change and then compiled libsodiumUE4.sln for Release/x64. Now it works.
